### PR TITLE
feat: Hide remote branches created by the Renovate action by default

### DIFF
--- a/src/main/kotlin/com/gitvantage/model/Meta.kt
+++ b/src/main/kotlin/com/gitvantage/model/Meta.kt
@@ -72,7 +72,7 @@ object Meta {
      * Hidden, not filtered away — the same bargain as dotfiles. The count stays visible in the
      * section header and one click brings them back, so nothing disappears without saying so.
      */
-    val DEFAULT_HIDE_BRANCH_PATTERNS = listOf("origin/dependabot/.*")
+    val DEFAULT_HIDE_BRANCH_PATTERNS = listOf("origin/dependabot/.*", "origin/renovate(-action)?/.*")
 
     /**
      * Compile [patterns] to regexes, dropping any that don't parse.


### PR DESCRIPTION
Note that "renovate" is the default namespace, but the docs [1] say it "should be configured to a value other than the default to prevent interference with e.g. the Renovate GitHub App", which is why the somewhat common "-action" suffix is optionally covered as well.