### PR TITLE
chore: Remove a superfluous return value

### DIFF
--- a/src/main/kotlin/com/gitvantage/app/Actions.kt
+++ b/src/main/kotlin/com/gitvantage/app/Actions.kt
@@ -69,6 +69,5 @@ object Actions {
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
-        true
     }.isSuccess
 }


### PR DESCRIPTION
This is a fixup for ca5dbb1.