### PR TITLE
Copy a repository's absolute path from the detail pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ GitVantage watches all your local repositories and gives you, in one place:
 - **Namespaced tags + notes** — organize repos with `owner:me`, `lang:kotlin`, … (with inline autocomplete), and keep per-repo working notes.
   Bulk-tag, untag, and act on many repos at once.
 - **A rich per-repo detail pane**:
+  - **Where it is on disk** — the repo's folder, `~`-folded so it reads at a glance, with the full absolute path one click away on the clipboard (hover for it in full).
   - Changed files (staged / modified / untracked) and a **GitHub-style side-by-side diff viewer** with character-level highlighting and a flattened file tree.
   - **Branches** with their tracking status vs upstream (ahead / behind / diverged / in sync) *and* vs mainline (merged / stale), one-click **switch**, **diff**, **copy the name**, and **delete** (mirrors `git branch -d/-D`).
   - **Remote branches** with last author, one-click checkout into a local tracking branch, and copy of the full ref.

--- a/src/main/kotlin/com/gitvantage/ui/Components.kt
+++ b/src/main/kotlin/com/gitvantage/ui/Components.kt
@@ -327,6 +327,17 @@ fun Badges(badges: List<Badge>, modifier: Modifier = Modifier, hasNote: Boolean 
     }
 }
 
+/**
+ * An absolute path with `$HOME` folded back to `~`, which is how the user thinks of it.
+ *
+ * A display form only — never what gets copied. `~` is a shell's expansion, not a path, so the
+ * thing on the clipboard stays absolute even where the thing on screen is folded.
+ */
+fun shortPath(path: String): String {
+    val home = System.getProperty("user.home").orEmpty()
+    return if (home.isNotEmpty() && path.startsWith(home)) "~" + path.removePrefix(home) else path
+}
+
 /** Wrap content in a hover tooltip that shows the full [path] (for truncated file names). */
 @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable

--- a/src/main/kotlin/com/gitvantage/ui/DetailPanel.kt
+++ b/src/main/kotlin/com/gitvantage/ui/DetailPanel.kt
@@ -79,6 +79,11 @@ import com.gitvantage.model.Stash
 @Composable
 fun DetailPanel(state: AppState, rv: RepoView) {
     val repo = rv.repo
+    // The tracked entry's path, forced absolute. Registry entries are written absolute, so this is
+    // almost always the id unchanged — but a hand-edited registry can hold a relative one, and
+    // "Copy path" has to be able to promise what its label says. Not canonicalised: resolving
+    // symlinks would hand back a path the user has never seen for a checkout they reach by one.
+    val repoPath = remember(repo.id) { java.io.File(repo.id).absolutePath }
     val staged = repo.files.filter { it.section == "staged" }
     val modified = repo.files.filter { it.section == "unstaged" }
     val untracked = repo.files.filter { it.section == "untracked" }
@@ -136,6 +141,29 @@ fun DetailPanel(state: AppState, rv: RepoView) {
                     modifier = Modifier.weight(1f, fill = false))
                 // Only when there's a real branch name to copy — a detached HEAD or a non-repo has none.
                 if (repo.hasNamedBranch) CopyPill(repo.branch, "Copy branch")
+            }
+
+            // Where this repository actually is on disk, and a way to take it with you.
+            //
+            // The pane never said. The name at the top is a folder name, and folder names repeat —
+            // two checkouts of the same project, a fork beside its upstream, `web` under three
+            // different clients — so the one line that tells them apart was missing from the one
+            // surface that talks about a single repo. It earns its place by answering that on
+            // sight, before anyone reaches for the pill.
+            //
+            // Shown `~`-folded because that is how the path is read, copied absolute because that
+            // is how it is used — pasted into a `cd`, a script, another tool's "open folder", where
+            // a `~` only survives if a shell happens to expand it. The tooltip shows the absolute
+            // form, so the two are never a secret from each other.
+            Row(
+                Modifier.padding(top = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                PathTip(repoPath, Modifier.weight(1f, fill = false)) {
+                    Txt(shortPath(repoPath), 11.5.sp, Tokens.muted2, font = MonoFont)
+                }
+                CopyPill(repoPath, "Copy path")
             }
 
             // If this repo is itself a submodule of a parent that's also tracked, link to it.

--- a/src/main/kotlin/com/gitvantage/ui/Worktrees.kt
+++ b/src/main/kotlin/com/gitvantage/ui/Worktrees.kt
@@ -657,9 +657,3 @@ private fun lastCommitLine(wt: Worktree): String = when {
 /** Git's relative date compacted to the strip's width — "2 hours ago" reads as "2h". */
 private fun compactAgo(wt: Worktree): String? =
     wt.lastEpoch?.let { Meta.compactDuration(System.currentTimeMillis() - it * 1000) }
-
-/** An absolute path with `$HOME` folded back to `~`, which is how the user thinks of it. */
-private fun shortPath(path: String): String {
-    val home = System.getProperty("user.home").orEmpty()
-    return if (home.isNotEmpty() && path.startsWith(home)) "~" + path.removePrefix(home) else path
-}


### PR DESCRIPTION
## What

The detail pane now shows where the selected repository is on disk, with a **Copy path** pill beside it.

The path line sits directly under the branch line and mirrors it — path on the left, copy pill on the right where `Copy branch` already sits. It reuses `CopyPill`, so it gets the same in-place "✓ Copied" confirmation as everything else in the app that copies.

## Why

The pane never said where a repo actually is. The name at the top is a *folder* name, and folder names repeat — two checkouts of the same project, a fork beside its upstream, `web` under three different clients — so the one line that tells them apart was missing from the one surface dedicated to a single repo. And there was no way to get that path out of the app at all, short of opening a terminal in it and running `pwd`.

## Notes for review

- **Shown folded, copied absolute.** The line reads `~/source/gitvantage`; the clipboard gets `/home/raman/source/gitvantage`. `~` is a shell's expansion rather than a path, and the thing you paste this into is often a script or another tool's "open folder" field where nothing expands it. The hover tooltip carries the absolute form, so the two aren't a secret from each other.
- **`File(repo.id).absolutePath`, not the id as stored.** Registry entries are written absolute already, so this is almost always the id unchanged — but a hand-edited registry can hold a relative path, and a button labelled "Copy path" has to be able to promise what it says.
- **Not canonicalised.** Resolving symlinks would hand back a folder the user has never seen for a checkout they reach by one. Absolute is the promise; canonical is a different one.
- **`shortPath` moved** out of `Worktrees.kt` into `Components.kt`, beside `PathTip` — two surfaces now fold `$HOME` the same way, and two copies of that helper would drift.
- **Scope:** repos only. The worktree cards in the same pane show their paths but have no copy action; that's a different object and I left it alone rather than widening the change.

## Verification

Built and run in an isolated KWin/Wayland session against a scratch registry (nothing touched the real one): clicking the pill puts `/home/raman/source/gitvantage` on the clipboard while the line reads `~/source/gitvantage`, and the worktree cards still render their paths correctly after the helper move.

`./gradlew test detekt` clean — 168 tests, 0 failures (confirmed from the JUnit result XML, not just the build status).

