### PR TITLE
fix: make "Open in …" work on macOS and Windows

### DIFF
--- a/src/main/kotlin/com/gitvantage/app/Actions.kt
+++ b/src/main/kotlin/com/gitvantage/app/Actions.kt
@@ -5,69 +5,337 @@ package com.gitvantage.app
 
 import com.gitvantage.git.GitLog
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 /**
  * "Open in …" launches for the detail panel. All fire-and-forget: the external app is
  * started detached (we never wait on it), and each entry point tries a list of candidate
  * commands so it works across setups, returning false only if none could be started.
+ *
+ * Every chain is per-platform, because none of these actions has a portable spelling. What the
+ * chains share is that a rung is *resolved* before it is tried (see [Programs]) rather than being
+ * tried to find out whether it exists — start-means-success is a Linux-only test, and building
+ * macOS and Windows on it is why these did nothing at all there.
  */
 object Actions {
 
-    fun openTerminal(path: String): Boolean {
+    // ---- Terminal -----------------------------------------------------------------------------
+
+    fun openTerminal(path: String): Boolean = launchFirst(terminals(path), File(path)) != null
+
+    /**
+     * Where a terminal comes from, per platform.
+     *
+     * Linux is the list this file has always had, now resolved rather than probed by exec.
+     *
+     * macOS has no system-wide "default terminal" setting to consult — there is no Launch Services
+     * handler for the role — so the order is the useful one: whatever `$TERMINAL` names, then
+     * iTerm, then Ghostty, then Terminal.app, which is always installed and so is a real floor.
+     * Every rung is `open -a`, which hands the directory to the app and gets a window at that
+     * directory; the list is deliberately short, holding only apps whose handling of a directory
+     * argument is dependable. A rung that "works" but opens somewhere else is worse than falling
+     * through to Terminal.app, which opens in the right place.
+     *
+     * Windows does have a default-terminal setting, and [winConsole] is how it gets honoured.
+     */
+    private fun terminals(path: String): List<Candidate> {
         val term = System.getenv("TERMINAL")?.takeIf { it.isNotBlank() }
-        val candidates = buildList {
-            if (term != null) add(listOf(term))
-            add(listOf("konsole", "--workdir", path)) // KDE
-            add(listOf("gnome-terminal", "--working-directory=$path"))
-            add(listOf("kgx", "--working-directory=$path"))
-            add(listOf("alacritty", "--working-directory", path))
-            add(listOf("kitty", "--directory", path))
-            add(listOf("xterm"))
+        return buildList {
+            when (Os.current) {
+                Os.LINUX -> {
+                    if (term != null) add(exe(term))
+                    add(exe("konsole", "--workdir", path)) // KDE
+                    add(exe("gnome-terminal", "--working-directory=$path"))
+                    add(exe("kgx", "--working-directory=$path"))
+                    add(exe("alacritty", "--working-directory", path))
+                    add(exe("kitty", "--directory", path))
+                    add(exe("xterm"))
+                }
+                Os.MAC -> {
+                    if (term != null) add(exe(term))
+                    add(macApp("iTerm", path))
+                    add(macApp("Ghostty", path))
+                    add(macApp("Terminal", path))
+                }
+                Os.WINDOWS -> {
+                    // Windows Terminal first, and by name: it is a GUI application, so unlike the
+                    // console shells below it can be started directly and told which directory to
+                    // open. `-d` also keeps the user's chosen default profile.
+                    add(exe("wt.exe", "-d", path))
+                    add(winConsole())
+                }
+            }
         }
-        return launchFirst(candidates, File(path)) != null
     }
 
-    fun openFolder(path: String): Boolean = launchFirst(listOf(listOf("xdg-open", path)), File(path)) != null
+    /**
+     * A console shell in a window of its own.
+     *
+     * It has to go through `cmd`'s `start` builtin. A console program started straight from this
+     * process gets no window: `ProcessBuilder` has no way to ask Windows for `CREATE_NEW_CONSOLE`,
+     * and this is a GUI process with no console of its own to inherit — so `cmd.exe` would run
+     * invisibly, attached to the pipes [launch] hands it, and the user would see nothing happen.
+     *
+     * `start` is also what makes the user's choice count. Allocating a new console is the moment
+     * Windows 11 consults its console-delegation setting and hands the session to whichever
+     * terminal was set as the default, so this rung is "the default terminal" rather than merely
+     * "cmd" — and degrades to conhost on Windows 10, which is the documented worst case.
+     *
+     * The directory comes from [launch]'s working directory, which `start` passes to the child;
+     * spelling it as an argument instead would mean quoting a path through two levels of parsing.
+     */
+    private fun winConsole() = Candidate(listOf("cmd.exe", "/c", "start", "", "cmd.exe")) {
+        Launch(listOf(Programs.comSpec(), "/c", "start", "", "cmd.exe"))
+    }
+
+    // ---- Folder, URL, IDE, git clients --------------------------------------------------------
+
+    fun openFolder(path: String): Boolean = launchFirst(folders(path), File(path)) != null
+
+    /** `explorer.exe` is a GUI application, so it needs no `start` wrapper — and it exits 1 even
+     *  when it succeeded, which costs nothing here because nothing waits on it. */
+    private fun folders(path: String): List<Candidate> = when (Os.current) {
+        Os.LINUX -> listOf(exe("xdg-open", path))
+        Os.MAC -> listOf(exe("open", path))
+        Os.WINDOWS -> listOf(exe("explorer.exe", path))
+    }
 
     /** Open a URL in the default browser. */
     fun openUrl(url: String): Boolean =
-        launchFirst(listOf(listOf("xdg-open", url), listOf("open", url)), File(System.getProperty("user.home"))) != null
+        launchFirst(urls(url), File(System.getProperty("user.home"))) != null
 
-    fun openIde(path: String): Boolean = launchFirst(
-        listOf(listOf("idea", path), listOf("idea.sh", path), listOf("code", path), listOf("codium", path)),
-        File(path),
-    ) != null
+    /**
+     * Windows goes through `explorer.exe` rather than the more familiar `cmd /c start <url>`
+     * because `start` is a shell builtin and the shell reads `&` as a command separator — every
+     * URL with a second query parameter would be cut in half and the tail run as a command.
+     * `explorer` is executed directly, with no shell in the way to reinterpret anything.
+     */
+    private fun urls(url: String): List<Candidate> = when (Os.current) {
+        Os.LINUX -> listOf(exe("xdg-open", url))
+        Os.MAC -> listOf(exe("open", url))
+        Os.WINDOWS -> listOf(
+            exe("explorer.exe", url),
+            exe("rundll32.exe", "url.dll,FileProtocolHandler", url),
+        )
+    }
 
-    fun openGitGui(path: String): Boolean = launchGitClient(path, listOf(listOf("git", "gui")))
+    fun openIde(path: String): Boolean = launchFirst(ides(path), File(path)) != null
+
+    /** The `.app` rungs are for macOS installs done entirely through the GUI — JetBrains Toolbox
+     *  and VS Code both leave their `PATH` shims out unless asked, so the editor is plainly there
+     *  and no command names it. */
+    private fun ides(path: String): List<Candidate> = buildList {
+        add(exe("idea", path))
+        add(exe("idea.sh", path))
+        add(exe("code", path))
+        add(exe("codium", path))
+        if (Os.current == Os.MAC) {
+            add(macApp("IntelliJ IDEA", path))
+            add(macApp("Visual Studio Code", path))
+        }
+    }
+
+    fun openGitGui(path: String): Boolean = launchGitClient(path, gitGuis())
+
+    /**
+     * `git gui` is a subcommand, not a program, and that distinction is the whole bug.
+     *
+     * Resolving `git` says nothing about whether `git gui` exists, because git-gui ships
+     * separately from git nearly everywhere — its own Homebrew formula on macOS, its own package
+     * on most distributions. So the ordinary machine has git and no git-gui, and there `git gui`
+     * starts perfectly well, writes "git: 'gui' is not a git command" to the stream [launch]
+     * discards, and exits 1 long after this fire-and-forget launch reported success. A menu item
+     * that does nothing, in silence, and even logs itself to the git console as launched.
+     *
+     * So each git is asked where its subcommands live and only one that actually has git-gui
+     * becomes a rung. Every git on the search path, not just the first: launched from Finder, the
+     * first git on a Mac is Apple's `/usr/bin/git`, which has no git-gui, and stopping there would
+     * report "not installed" on precisely the Macs where someone installed it.
+     */
+    private fun gitGuis(): List<Candidate> {
+        val gits = Programs.locate("git")
+        // Nothing to offer, but the chain still needs a rung to name in the git console — the
+        // record of a launch that could not happen is the only trace the user gets.
+        if (gits.isEmpty()) return listOf(Candidate(listOf("git", "gui")) { null })
+        return gits.map { git ->
+            Candidate(listOf("git", "gui")) {
+                findGitGui(git)?.let { gui ->
+                    // Both directories, because finding git-gui is only half of it: the git we are
+                    // about to run has to find it too, and it looks on its *own* PATH, not ours.
+                    // A `.app` launched from Finder is handed launchd's PATH — /usr/bin and three
+                    // more — so a Homebrew git-gui is invisible to the child even though we just
+                    // located it. git's own directory goes on as well, so git-gui shells out to
+                    // the git it was matched with rather than to whichever one comes first.
+                    Launch(listOf(git.absolutePath, "gui"), listOfNotNull(gui.parentFile, git.parentFile))
+                }
+            }
+        }
+    }
+
+    /** Where a git-gui has already been found, keyed by the git that will run it. Hits only. */
+    private val gitGuis = ConcurrentHashMap<String, File>()
+
+    /**
+     * The git-gui [git] would run, or null if it has none.
+     *
+     * This mirrors how git resolves a subcommand, which is the only definition that matches what
+     * happens at the click. git looks in its exec-path *and then falls back to `PATH`* — the
+     * fallback being how every third-party `git-foo` works at all — so checking `--exec-path`
+     * alone answers the question wrongly for the ordinary macOS install, where Homebrew ships
+     * git-gui as its own package and lands it in `/opt/homebrew/bin` while git's exec-path sits
+     * off in the Cellar. That reports "not installed" for a git-gui that runs fine in a terminal.
+     *
+     * The middle rung covers the packagers who instead link git-gui beside git rather than inside
+     * git's own keg: for a git at `<prefix>/bin/git`, `<prefix>/libexec/git-core`. Both the literal
+     * and the symlink-resolved prefix, since a `bin/git` that is a symlink into a versioned
+     * directory has two plausible answers and they cost one `stat` each.
+     */
+    private fun findGitGui(git: File): File? = gitGuis[git.absolutePath] ?: run {
+        val homes = buildList {
+            execPathOf(git)?.let { add(File(it)) }
+            listOf(git, git.canonicalFile).forEach { g ->
+                g.parentFile?.parentFile?.let { add(File(it, "libexec/git-core")) }
+            }
+        }
+        val found = homes.firstNotNullOfOrNull { home ->
+            GIT_GUI_NAMES.map { File(home, it) }.firstOrNull { it.isFile }
+        } ?: Programs.locate("git-gui").firstOrNull()
+        found?.also { gitGuis[git.absolutePath] = it }
+    }
+
+    /** Where [git] keeps its subcommands, as git itself reports it. Reads no repository and
+     *  touches no network, so it is cheap enough to ask on a click. */
+    private fun execPathOf(git: File): String? = runCatching {
+        val probe = ProcessBuilder(git.absolutePath, "--exec-path")
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+        // Read before waiting: the pipe would fill and deadlock a chatty command, and the read
+        // ends at the process's own exit anyway, so the wait below is already satisfied.
+        val out = probe.inputStream.bufferedReader().use { it.readText() }.trim()
+        if (probe.waitFor(1, TimeUnit.SECONDS) && probe.exitValue() == 0) out.ifEmpty { null } else null
+    }.getOrNull()
+
+    /** Git for Windows spells the subcommand `git-gui.exe`; everyone else has no extension. */
+    private val GIT_GUI_NAMES = listOf("git-gui", "git-gui.exe")
 
     fun openGitButler(path: String): Boolean = launchGitClient(
         path,
-        listOf(listOf("but", "--path", path), listOf("gitbutler-tauri"), listOf("gitbutler")),
+        listOf(exe("but", "--path", path), exe("gitbutler-tauri"), exe("gitbutler")),
     )
 
-    /** Try each command in [cmds] with cwd [dir]; the first that starts, or null if none did.
+    // ---- Machinery ----------------------------------------------------------------------------
+
+    /**
+     * One rung of a chain: how it reads, and what it would actually run.
+     *
+     * [cmd] is the human-facing spelling — `code /repo`, not the absolute path to `code.cmd` with
+     * an interpreter in front of it — and is what the git console records. [resolve] answers with
+     * the real command, or null when the program isn't installed, which is the question a chain
+     * has to be able to ask before it commits to a rung.
+     */
+    private class Candidate(val cmd: List<String>, val resolve: () -> Launch?)
+
+    /**
+     * A resolved rung: the command, and any directories the child must see on its `PATH`.
+     *
+     * [pathPrefix] is empty for almost everything, because almost everything here is launched by
+     * absolute path and needs to look nothing up. It exists for `git gui`, where the program we
+     * run is git and the thing that has to be found is a *subcommand* — a lookup performed by the
+     * child, against the child's environment, after we have already stopped being able to see it.
+     */
+    private class Launch(val cmd: List<String>, val pathPrefix: List<File> = emptyList())
+
+    /** A rung naming a program to be found on `PATH`. */
+    private fun exe(program: String, vararg args: String) = Candidate(listOf(program) + args) {
+        Programs.resolve(program)?.plus(args)?.let(::Launch)
+    }
+
+    /**
+     * A rung naming a macOS application bundle, opened with the directory as its argument.
+     *
+     * The guard is the point. `open -a Ghostty` starts, and returns, whether or not Ghostty is
+     * installed — the failure is `open`'s own exit code, long after this fire-and-forget launch
+     * has reported success — so without a prior Launch Services lookup the first `.app` rung would
+     * swallow the whole chain on every Mac.
+     */
+    private fun macApp(app: String, vararg args: String): Candidate {
+        val cmd = listOf("open", "-a", app) + args
+        return Candidate(cmd) { Launch(cmd).takeIf { macAppInstalled(app) } }
+    }
+
+    /** Applications a probe has already found. Hits only, for the reason [Programs] caches hits
+     *  only: an app installed while the dashboard is open should show up on the next click. */
+    private val macApps = ConcurrentHashMap.newKeySet<String>()
+
+    /** `open -Ra` resolves an application without launching it, exiting 0 only if it is registered
+     *  — which finds it wherever it lives, including `~/Applications` and Setapp, as a search of
+     *  `/Applications` would not. Bounded: this runs on the UI thread from a click, and a Launch
+     *  Services lookup that has not answered within a second is not going to. */
+    private fun macAppInstalled(app: String): Boolean = app in macApps || run {
+        runCatching {
+            val probe = ProcessBuilder("open", "-Ra", app)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            if (probe.waitFor(1, TimeUnit.SECONDS)) probe.exitValue() == 0 else { probe.destroy(); false }
+        }.getOrDefault(false).also { if (it) macApps += app }
+    }
+
+    /** Try each rung of [cmds] with cwd [dir]; the first that started, or null if none did.
      *  Returns the command rather than a flag so the git-client launchers can record what ran. */
-    private fun launchFirst(cmds: List<List<String>>, dir: File): List<String>? =
-        cmds.firstOrNull { launch(it, dir) }
+    private fun launchFirst(cmds: List<Candidate>, dir: File): List<String>? =
+        cmds.firstNotNullOfOrNull { candidate ->
+            candidate.resolve()?.takeIf { launch(it, dir) }?.cmd
+        }
 
     /** Launch a git client and record it: what the user does inside one is real git mutation, so
      *  the entry is the console's only account of the dashboard state that jumps afterwards.
      *  Names the command that actually started, or the preferred candidate if none would. */
-    private fun launchGitClient(path: String, cmds: List<List<String>>): Boolean {
+    private fun launchGitClient(path: String, cmds: List<Candidate>): Boolean {
         val dir = File(path)
         val started = launchFirst(cmds, dir)
-        GitLog.recordLaunch(dir.name.ifEmpty { path }, started ?: cmds.first(), started != null)
+        GitLog.recordLaunch(dir.name.ifEmpty { path }, started ?: cmds.first().cmd, started != null)
         return started != null
     }
 
-    /** Launch [cmd] in [dir] and return true on success or false on failure, e.g. if the command
+    /**
+     * What each "Open in …" action would run right now, or null where nothing resolved.
+     *
+     * For `--smoke-test`. These launches fail silently by nature — a chain that resolves nothing
+     * looks exactly like a button that does nothing — and this is the only way to ask the question
+     * on a machine without clicking, which matters most on the two platforms where the answer used
+     * to be "nothing, on every rung".
+     */
+    internal fun resolutions(path: String): List<Pair<String, List<String>?>> = listOf(
+        "terminal" to firstResolved(terminals(path)),
+        "file manager" to firstResolved(folders(path)),
+        "browser" to firstResolved(urls("https://example.com/")),
+        "IDE" to firstResolved(ides(path)),
+        "git GUI" to firstResolved(gitGuis()),
+    )
+
+    private fun firstResolved(cmds: List<Candidate>): List<String>? =
+        cmds.firstNotNullOfOrNull { it.resolve()?.cmd }
+
+    /** Launch [what] in [dir] and return true on success or false on failure, e.g. if the command
      *  was not found or is not launchable.
      */
-    private fun launch(cmd: List<String>, dir: File): Boolean = runCatching {
-        ProcessBuilder(cmd)
+    private fun launch(what: Launch, dir: File): Boolean = runCatching {
+        val pb = ProcessBuilder(what.cmd)
             .directory(dir.takeIf { it.isDirectory })
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
-            .start()
+        if (what.pathPrefix.isNotEmpty()) {
+            val env = pb.environment()
+            // Prepended, not replaced: the inherited PATH is still the user's, and the child may
+            // need the rest of it. PATH_SEPARATOR rather than a literal, since this runs on
+            // Windows too, where it is a semicolon.
+            val prefix = what.pathPrefix.map { it.absolutePath }.distinct()
+            env["PATH"] = (prefix + env["PATH"].orEmpty())
+                .filter { it.isNotBlank() }
+                .joinToString(File.pathSeparator)
+        }
+        pb.start()
     }.isSuccess
 }

--- a/src/main/kotlin/com/gitvantage/app/Os.kt
+++ b/src/main/kotlin/com/gitvantage/app/Os.kt
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Raman Gupta
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.gitvantage.app
+
+/**
+ * Which desktop this copy is running on, resolved once.
+ *
+ * Only the launcher code in [Actions] and [Programs] branches on it, and only because "open this
+ * in a terminal / a file manager / a browser" has no portable spelling — every platform answers it
+ * with a different program, and two of the three cannot even report failure the same way.
+ */
+enum class Os {
+    LINUX,
+    MAC,
+    WINDOWS,
+    ;
+
+    companion object {
+        /**
+         * [MAC] is tested before [WINDOWS] deliberately: the substring "win" is inside "darwin",
+         * so the obvious `contains("win")` first would classify a Mac as Windows the day some JVM
+         * spells `os.name` that way. Anything unrecognised falls to [LINUX], which is where the
+         * freedesktop tools this app already relied on live.
+         */
+        val current: Os = from(System.getProperty("os.name").orEmpty())
+
+        /** Split out from [current] so the ordering above can actually be tested — the property it
+         *  reads is fixed for the life of the process. */
+        internal fun from(osName: String): Os = osName.lowercase().let {
+            when {
+                it.contains("mac") || it.contains("darwin") -> MAC
+                it.contains("win") -> WINDOWS
+                else -> LINUX
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/gitvantage/app/Programs.kt
+++ b/src/main/kotlin/com/gitvantage/app/Programs.kt
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Raman Gupta
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.gitvantage.app
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Finds the external programs [Actions] launches, and says how to run them.
+ *
+ * [Actions] used to answer "is this installed?" by trying to start it and seeing whether the exec
+ * failed. That is only an answer on Linux. `open -a iTerm` and `cmd /c start` start perfectly well
+ * whether or not the thing they front exists, so a chain built on start-means-success stops at its
+ * first rung on macOS and Windows and silently does nothing at all. Resolving the program up front
+ * is what lets a fallback chain fall back.
+ */
+internal object Programs {
+
+    /**
+     * Directories searched in addition to `PATH`.
+     *
+     * A macOS `.app` launched from Finder or the Dock inherits launchd's `PATH`, which is
+     * `/usr/bin:/bin:/usr/sbin:/sbin` and nothing else — not the `PATH` the user's shell builds.
+     * Every CLI shim someone actually installed lives outside it: Homebrew in `/opt/homebrew/bin`
+     * or `/usr/local/bin`, MacPorts in `/opt/local/bin`, JetBrains Toolbox and GitButler in
+     * `~/.local/bin`. Scanning `PATH` alone would find none of them and report a bare Mac.
+     *
+     * Harmless on Linux, where these are the same directories a session `PATH` already lists.
+     */
+    private val extraDirs: List<String> =
+        if (Os.current == Os.WINDOWS) emptyList()
+        else listOf(
+            "/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin",
+            System.getProperty("user.home") + "/.local/bin",
+        )
+
+    private val searchDirs: List<File> by lazy {
+        (System.getenv("PATH").orEmpty().split(File.pathSeparatorChar) + extraDirs)
+            .filter { it.isNotBlank() }
+            .distinct()
+            .map(::File)
+    }
+
+    /**
+     * The extensions a bare name may carry, in the order Windows tries them; a single empty string
+     * everywhere else. The empty string is appended on Windows too, so a candidate already spelled
+     * with its extension (`wt.exe`) still resolves once every real extension has missed.
+     */
+    private val searchExts: List<String> by lazy {
+        if (Os.current != Os.WINDOWS) listOf("")
+        else (System.getenv("PATHEXT") ?: ".COM;.EXE;.BAT;.CMD")
+            .split(';').filter { it.isNotBlank() } + ""
+    }
+
+    /**
+     * Resolved invocations, keyed by the name asked for. Hits only: a program that was found is
+     * not going to move, but one that was missing may well be installed while the app is running,
+     * and remembering that it was absent would mean "Open in IDE" stayed dead until a restart. A
+     * repeated miss costs a directory scan, which is a few stats.
+     */
+    private val hits = ConcurrentHashMap<String, List<String>>()
+
+    /**
+     * How to run [program], or null if it isn't installed. The result is a complete command
+     * prefix: usually the resolved absolute path, but see [invocation] for the Windows exception.
+     */
+    fun resolve(program: String): List<String>? =
+        hits[program] ?: find(program, searchDirs, searchExts)
+            ?.let { invocation(it, Os.current) }
+            ?.also { hits[program] = it }
+
+    /**
+     * *Every* executable named [program] on the real search path, in search order — where
+     * [resolve] answers "which one runs", this answers "which ones are there".
+     *
+     * The distinction only matters when the first hit is not necessarily the right one. Asking a
+     * git for `git gui` is the case that forced it: on a Mac the first git is Apple's
+     * `/usr/bin/git`, which carries no git-gui, while the Homebrew git that does is further down.
+     * Taking the first and concluding "not installed" would be wrong on exactly the machines where
+     * someone went and installed it.
+     *
+     * Uncached, unlike [resolve]: the callers scan the results, so a stale list is worse than a
+     * few stats.
+     */
+    fun locate(program: String): List<File> = findAll(program, searchDirs, searchExts)
+
+    /**
+     * The first executable named [program] under [dirs], trying each of [exts] in turn.
+     *
+     * [dirs] is the outer loop and [exts] the inner one, which is the order Windows itself
+     * searches: an earlier directory's `foo.cmd` beats a later directory's `foo.exe`.
+     */
+    fun find(program: String, dirs: List<File>, exts: List<String>): File? =
+        findAll(program, dirs, exts).firstOrNull()
+
+    /**
+     * As [find], but every match rather than the first.
+     *
+     * A name that already carries a separator is a location rather than a name, so it is tested
+     * exactly as given — that is how a `$TERMINAL` set to an absolute path resolves — and there is
+     * then at most one answer to give.
+     */
+    fun findAll(program: String, dirs: List<File>, exts: List<String>): List<File> {
+        if (program.contains('/') || program.contains('\\')) {
+            return listOfNotNull(File(program).takeIf(::executable))
+        }
+        return dirs.flatMap { dir ->
+            exts.mapNotNull { ext -> File(dir, program + ext).takeIf(::executable) }
+        }
+    }
+
+    /**
+     * `canExecute()` means nothing on Windows — it reports the read-only attribute, not an execute
+     * bit, so it is true for every readable file and would reject nothing. There, landing on a
+     * `PATHEXT` name is the whole test. File *size* deliberately isn't part of it: a Windows
+     * app-execution alias — which is how `wt.exe` appears on `PATH` — is a zero-byte reparse
+     * point, and requiring a non-empty file would hide Windows Terminal on every machine.
+     */
+    private fun executable(f: File): Boolean = f.isFile && (Os.current == Os.WINDOWS || f.canExecute())
+
+    /**
+     * Windows cannot execute a batch file. `CreateProcess` starts real images only, so `code.cmd`
+     * — which is how VS Code, and nearly every Node-based CLI, lands on `PATH` — has to be handed
+     * to the interpreter instead. This is why "Open in IDE" did nothing on Windows even though
+     * `code` was plainly installed: the exec failed, and the chain read that as "not installed".
+     */
+    fun invocation(f: File, os: Os): List<String> {
+        val path = f.absolutePath
+        val isBatch = os == Os.WINDOWS && path.substringAfterLast('.', "").lowercase() in BATCH_EXTS
+        return if (isBatch) listOf(comSpec(), "/c", path) else listOf(path)
+    }
+
+    private val BATCH_EXTS = setOf("cmd", "bat")
+
+    /** The command interpreter, from the environment rather than assumed — a Windows install can
+     *  sit somewhere other than `C:\Windows\System32`, and `ComSpec` is where it says so. */
+    fun comSpec(): String = System.getenv("ComSpec")?.takeIf { it.isNotBlank() } ?: "cmd.exe"
+}

--- a/src/main/kotlin/com/gitvantage/smoke/SmokeChecks.kt
+++ b/src/main/kotlin/com/gitvantage/smoke/SmokeChecks.kt
@@ -3,6 +3,8 @@
 
 package com.gitvantage.smoke
 
+import com.gitvantage.app.Actions
+import com.gitvantage.app.Os
 import dev.nucleusframework.darkmodedetector.NoopDarkModeDetector
 import dev.nucleusframework.darkmodedetector.getPlatformDarkModeDetector
 import dev.nucleusframework.fswatcher.FsWatchers
@@ -68,6 +70,7 @@ fun runSmokeChecks(): Int {
     checkXdgFileChooserProxy()
     checkMacOsFileChooserBridge()
     checkNotifications()
+    checkOpenInTargets()
 
     val failed = results.filter { it.first == Status.FAIL }
     println()
@@ -500,4 +503,39 @@ private fun checkNotifications() {
         },
         onFailure = { record(Status.FAIL, name, "initialisation threw: $it") },
     )
+}
+
+/**
+ * Whether the "Open in …" actions have anything to open with.
+ *
+ * This is the check that would have caught the reason they did nothing at all on macOS and
+ * Windows. Their chains launch detached and never wait, so a chain that resolves to nothing is
+ * indistinguishable from a button that works — there is no error to surface, no exit code to read,
+ * and the user's only report is "clicking it does nothing".
+ *
+ * Only the floors are failures, and each platform's floor is different. macOS ships Terminal.app,
+ * `open` and Safari, and Windows ships `cmd.exe` and `explorer.exe`, so on those two a missing
+ * terminal, file manager or browser is a real defect in the chain above. Linux guarantees none of
+ * them — a headless CI runner legitimately has no terminal emulator and no `xdg-open` — so there
+ * an empty answer is reported and skipped rather than failed. The IDE and the git GUI are
+ * informational anywhere, being optional on every platform; what makes them worth printing is that
+ * "nothing resolved" is the one thing their silence at the click cannot tell you apart from.
+ */
+private fun checkOpenInTargets() {
+    val required = when (Os.current) {
+        Os.LINUX -> emptySet()
+        else -> setOf("terminal", "file manager", "browser")
+    }
+    Actions.resolutions(System.getProperty("user.home")).forEach { (what, cmd) ->
+        val name = "Open in $what"
+        when {
+            cmd != null -> record(Status.PASS, name, cmd.joinToString(" "))
+            what in required -> record(
+                Status.FAIL, name,
+                "nothing resolved, but ${Os.current.name.lowercase()} always has one — the " +
+                    "chain in Actions is wrong or Programs cannot see it, and the button is dead",
+            )
+            else -> record(Status.SKIP, name, "nothing installed to handle it")
+        }
+    }
 }

--- a/src/test/kotlin/com/gitvantage/app/ProgramResolutionTest.kt
+++ b/src/test/kotlin/com/gitvantage/app/ProgramResolutionTest.kt
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Raman Gupta
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.gitvantage.app
+
+import de.infix.testBalloon.framework.core.testSuite
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * How [Programs] decides an external program exists and how it should be run — the pure half of
+ * the "Open in …" fix, which is the half that can be checked without a Mac or a Windows box.
+ *
+ * [Programs.find] and [Programs.invocation] take their search path and their platform as arguments
+ * precisely so this suite can pose the Windows questions from Linux; only the caching wrapper
+ * reads the real environment.
+ */
+val ProgramResolution by testSuite {
+
+    /** A file at [name] under [dir], executable, so it passes the Unix half of the check. */
+    fun program(dir: File, name: String): File =
+        File(dir, name).apply { writeText(""); setExecutable(true) }
+
+    test("a bare name resolves to the first directory on the search path that has it") {
+        val root = createTempDirectory("progs").toFile()
+        val first = File(root, "first").apply { mkdirs() }
+        val second = File(root, "second").apply { mkdirs() }
+        program(second, "kitty")
+        val late = Programs.find("kitty", listOf(first, second), listOf(""))
+        assert(late == File(second, "kitty")) { "expected the only copy, got $late" }
+
+        val early = program(first, "kitty")
+        assert(Programs.find("kitty", listOf(first, second), listOf("")) == early) {
+            "an earlier directory must win, as it does in a shell"
+        }
+    }
+
+    test("on Windows the directory is the outer loop and the extension the inner one") {
+        // The order Windows itself searches, and the one that surprises people: an earlier
+        // directory's .cmd beats a later directory's .exe, even though .exe sorts first in PATHEXT.
+        val root = createTempDirectory("progs").toFile()
+        val first = File(root, "first").apply { mkdirs() }
+        val second = File(root, "second").apply { mkdirs() }
+        val exts = listOf(".COM", ".EXE", ".BAT", ".CMD", "")
+        val cmd = program(first, "code.CMD")
+        program(second, "code.EXE")
+        assert(Programs.find("code", listOf(first, second), exts) == cmd)
+    }
+
+    test("a name already carrying its extension still resolves") {
+        // wt.exe is spelled with the extension because that is how Windows Terminal is documented.
+        // Every real PATHEXT entry misses it — "wt.exe.EXE" — so the empty extension has to be
+        // there to catch it, or Windows Terminal is invisible.
+        val dir = createTempDirectory("progs").toFile()
+        val wt = program(dir, "wt.exe")
+        assert(Programs.find("wt.exe", listOf(dir), listOf(".COM", ".EXE", ".BAT", ".CMD", "")) == wt)
+    }
+
+    test("a name with a separator is a location, not something to search for") {
+        // This is how a $TERMINAL set to an absolute path resolves.
+        val dir = createTempDirectory("progs").toFile()
+        val term = program(dir, "myterm")
+        assert(Programs.find(term.absolutePath, emptyList(), listOf("")) == term)
+        assert(Programs.find("/nonexistent/myterm", emptyList(), listOf("")) == null)
+    }
+
+    test("a program that is not installed resolves to nothing") {
+        // The whole point of resolving up front: this is the answer a chain needs in order to try
+        // its next rung, and the answer the old start-means-success test could not give.
+        val dir = createTempDirectory("progs").toFile()
+        assert(Programs.find("definitely-not-installed", listOf(dir), listOf("")) == null)
+    }
+
+    test("a directory is not a program") {
+        val dir = createTempDirectory("progs").toFile()
+        File(dir, "code").mkdirs()
+        assert(Programs.find("code", listOf(dir), listOf("")) == null)
+    }
+
+    test("a Windows batch file is run through the interpreter, a real image directly") {
+        // CreateProcess cannot start a .cmd. VS Code lands on PATH as code.cmd, so without this
+        // wrapping "Open in IDE" fails on a Windows machine that plainly has VS Code installed —
+        // and the failure looks exactly like "not installed".
+        val dir = createTempDirectory("progs").toFile()
+        val batch = program(dir, "code.cmd")
+        val image = program(dir, "wt.exe")
+
+        val wrapped = Programs.invocation(batch, Os.WINDOWS)
+        assert(wrapped.size == 3 && wrapped[1] == "/c" && wrapped[2] == batch.absolutePath) {
+            "expected an interpreter invocation, got $wrapped"
+        }
+        assert(Programs.invocation(image, Os.WINDOWS) == listOf(image.absolutePath))
+        // Nothing is wrapped off Windows, where the extension carries no such meaning.
+        assert(Programs.invocation(batch, Os.LINUX) == listOf(batch.absolutePath))
+        assert(Programs.invocation(batch, Os.MAC) == listOf(batch.absolutePath))
+    }
+
+    test("every copy on the search path is findable, not just the first") {
+        // What "Open in git GUI" needs. The first git on a Mac launched from Finder is Apple's,
+        // which carries no git-gui; the Homebrew git that does is further down the path. Stopping
+        // at the first would report "not installed" on the machines where it *is* installed.
+        val root = createTempDirectory("progs").toFile()
+        val first = File(root, "first").apply { mkdirs() }
+        val second = File(root, "second").apply { mkdirs() }
+        val apple = program(first, "git")
+        val brew = program(second, "git")
+
+        val all = Programs.findAll("git", listOf(first, second), listOf(""))
+        assert(all == listOf(apple, brew)) { "expected both, in search order, got $all" }
+        // find stays the first of them, so nothing that only wants one answer changed.
+        assert(Programs.find("git", listOf(first, second), listOf("")) == apple)
+    }
+
+    test("a located path yields at most one answer") {
+        val dir = createTempDirectory("progs").toFile()
+        val git = program(dir, "git")
+        assert(Programs.findAll(git.absolutePath, listOf(dir), listOf("")) == listOf(git))
+        assert(Programs.findAll("/nonexistent/git", listOf(dir), listOf("")).isEmpty())
+    }
+
+    test("macOS is recognised before Windows") {
+        // "darwin" contains "win". Testing for Windows first would call a Mac a PC, and every
+        // launch would go to cmd.exe.
+        assert(Os.from("Mac OS X") == Os.MAC)
+        assert(Os.from("Darwin") == Os.MAC)
+        assert(Os.from("Windows 11") == Os.WINDOWS)
+        assert(Os.from("Linux") == Os.LINUX)
+        assert(Os.from("FreeBSD") == Os.LINUX)
+    }
+}


### PR DESCRIPTION
## What

Every "Open in …" action worked on Linux only. This makes Terminal, Folder, URL, IDE and git GUI work on macOS and Windows too.

| | Linux | macOS | Windows |
|---|---|---|---|
| Terminal | ✅ | ❌ freedesktop terminals only | ❌ same |
| Folder | ✅ | ❌ `xdg-open` only | ❌ same |
| URL | ✅ | ✅ (`open` fallback) | ❌ neither command exists |
| IDE | ✅ | ⚠️ only with shell shims | ❌ `code`/`idea` are batch files |
| git GUI | ✅ | ❌ | ❌ |

## Why a straight port wouldn't have fixed it

Availability was inferred from whether the exec succeeded. That is only an answer on Linux, where a missing binary fails with `ENOENT`. `open -a iTerm` and `cmd /c start` start perfectly well whether or not the thing they front is installed — so a chain built on start-means-success stops at its first rung and silently does nothing. Every rung is now *resolved* before it is tried.

## What changed

**`Programs.kt`** (new) — finds the program and says how to run it:
- `PATH` + `PATHEXT` search, directory outer / extension inner, matching Windows' own order.
- Batch files routed through `%ComSpec%`. `CreateProcess` cannot start a `.cmd`, and VS Code lands on Windows `PATH` as `code.cmd` — so "Open in IDE" failed on machines that plainly had it.
- Homebrew / MacPorts / `~/.local/bin` added to the search: a `.app` launched from Finder inherits launchd's `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) and can otherwise see none of the user's tools.

**`Os.kt`** (new) — three-way platform split. `MAC` is tested before `WINDOWS` because `"darwin"` contains `"win"`.

**`Actions.kt`** — per-platform chains:
- macOS opens app bundles behind an `open -Ra` Launch Services probe (`$TERMINAL` → iTerm → Ghostty → Terminal.app, which is a real floor).
- Windows Terminal is started directly (`wt.exe -d`); console shells go through `cmd`'s `start`, which is both the only way `ProcessBuilder` can get them a window — there is no way to request `CREATE_NEW_CONSOLE` — and what routes the new console to the user's chosen default terminal under Windows 11 console delegation.
- URLs avoid `start` entirely and use `explorer.exe`, since the shell would read `&` in a query string as a command separator and run the tail as a command.

**`git gui`** needed more than a resolved program: it is a *subcommand*, so `git` existing says nothing about it. git resolves one by searching its exec-path **and then falling back to `PATH`**, and the ordinary macOS install has git-gui as its own Homebrew package in `/opt/homebrew/bin`, in no git's exec-path. Both places are now searched, across every git found rather than the first — on a Mac the first is Apple's, which carries no git-gui. Finding it is only half: the child git repeats the lookup against *its* environment, so the directory holding git-gui and the matched git's own directory are prepended to the child's `PATH`.

## Testing

`ProgramResolutionTest` — 10 tests covering search order, batch wrapping, find-all-copies, and the darwin/win trap. The Windows cases take their platform as an argument, so they run from any host.

`SmokeChecks` gains an "Open in …" check reporting what each action resolves to. Worth its place because these launches fail *by being silent*: nothing waits on them, so a chain that resolves to nothing is indistinguishable from a button that works. It fails only on macOS/Windows, where Terminal.app, `explorer.exe` and `cmd.exe` are guaranteed floors, and skips on Linux, where a headless runner legitimately has none.

Manually verified on macOS by @rocketraman: Terminal opens iTerm, Folder opens Finder, IDE opens IntelliJ, git GUI now launches after `brew install git-gui`. Linux confirmed unregressed. The git-gui path was additionally reproduced end-to-end on Linux with a Mac-shaped fixture — git-gui reachable only through the extra search dirs and absent from the JVM's `PATH` — confirming the child finds it via the prefixed `PATH` and starts with the repo as its cwd.

## Reviewer notes

- **Windows is untested on real hardware.** `--smoke-test` is not wired into the release matrix (the jpackage-era gates were removed and not replaced) and `ci.yml` is ubuntu-only, so nothing exercises these chains on Windows automatically. The `wt.exe` alias resolution and the console-delegation behaviour of `start` are the two rungs most worth a real check. Adding a `--smoke-test` step to the release matrix would close this.
- **Known limitation:** a rung that starts successfully and *then* dies is still reported as success. git-gui was the case where that mattered and it is handled by detection rather than by watching the process; a terminal that crashes on launch would still be silent. Fixing that class generally means a non-blocking `process.onExit()` watcher.
- **Not included:** user-defined tool overrides. Deliberately deferred — that needs a settings surface, and the defaults land on their own.
